### PR TITLE
Fix check_code.sh failures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Data Cube Statistics Tools
 ##########################
 
-|Build Status| |Coverage Status| |CodeCov Status|
+|Build Status| |CodeCov Status|
 
 Data Cube Statistics is a an application used to calculate large scale temporal statistics
 on data stored using an `Open Data Cube`_ (`ODC`_) installation. It provides a
@@ -801,9 +801,7 @@ Release Notes
 .. _dataset metadata documents: http://datacube-core.readthedocs.io/en/stable/ops/config.html#dataset-metadata-document
 .. _strftime syntax: http://strftime.org/
 .. _hdmedians python package: https://github.com/daleroberts/hdmedians
-.. |Build Status| image:: https://travis-ci.org/GeoscienceAustralia/agdc_statistics.svg?branch=master
-   :target: https://travis-ci.org/GeoscienceAustralia/agdc_statistics
-.. |Coverage Status| image:: https://coveralls.io/repos/github/GeoscienceAustralia/agdc_statistics/badge.svg?branch=master
-   :target: https://coveralls.io/github/GeoscienceAustralia/agdc_statistics?branch=master
-.. |CodeCov Status| image:: https://codecov.io/gh/GeoscienceAustralia/agdc_statistics/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/GeoscienceAustralia/agdc_statistics
+.. |Build Status| image:: https://travis-ci.org/opendatacube/datacube-stats.svg?branch=master
+   :target: https://travis-ci.org/opendatacube/datacube-stats
+.. |CodeCov Status| image:: https://codecov.io/gh/opendatacube/datacube-stats/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/opendatacube/datacube-stats

--- a/datacube_stats/main.py
+++ b/datacube_stats/main.py
@@ -112,6 +112,9 @@ def with_or_without_qsub_runner():
         return identity
 
 
+def identity(f):
+    return f
+
 # pylint: disable=broad-except
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-arguments
@@ -137,8 +140,8 @@ def with_or_without_qsub_runner():
 @click.option('--version', is_flag=True, callback=_print_version,
               expose_value=False, is_eager=True)
 @ui.pass_index(app_name='datacube-stats')
-def main(index, stats_config_file, qsub, runner, save_tasks, load_tasks,
-         tile_index, tile_index_file, output_location, year, task_slice, batch):
+def main(index, stats_config_file, save_tasks, load_tasks,
+         tile_index, tile_index_file, output_location, year, task_slice, batch, runner=identity, qsub=None):
 
     try:
         _log_setup()

--- a/datacube_stats/main.py
+++ b/datacube_stats/main.py
@@ -677,10 +677,6 @@ def load_masked_tile_lazy(tile, masks,
 
     """
 
-    ii = range(tile.shape[0])
-    if reverse:
-        ii = ii[::-1]
-
     def load_slice(i):
         loc = [slice(i, i + 1), slice(None), slice(None)]
         d = GridWorkflow.load(tile[loc], **kwargs)
@@ -726,8 +722,12 @@ def load_masked_tile_lazy(tile, masks,
 
     extract = wrap_in_timer(load_slice, timer, 'loading_data')
 
-    for i in ii:
-        yield extract(i)
+    if reverse:
+        for i in reversed(range(tile.shape[0])):
+            yield extract(i)
+    else:
+        for i in range(tile.shape[0]):
+            yield extract(i)
 
 
 def load_masked_data_lazy(sub_tile_slice: Tuple[slice, slice, slice],

--- a/datacube_stats/utils/__init__.py
+++ b/datacube_stats/utils/__init__.py
@@ -373,8 +373,7 @@ def sorted_interleave(*iterators, key=lambda x: x, reverse=False):
         except StopIteration:
             return None
 
-    vv = map(advance, iterators)
-    vv = list(filter(lambda x: x is not None, vv))
+    vv = list(filter(lambda x: x is not None, map(advance, iterators)))
 
     while len(vv) > 0:
         (val, it), *vv = sorted(vv, key=lambda a: key(a[0]), reverse=reverse)

--- a/pylintrc
+++ b/pylintrc
@@ -1,39 +1,89 @@
-[MASTER]
-# ndexpr is crashing pylint. Hopefully remove this ignore when https://github.com/PyCQA/pylint/issues/1563 is fixed
-ignore=ndexpr
 
 [MESSAGES CONTROL]
-enable=python3
+# Disabled len-as-condition: Sometimes this allows more readable code as it's more explicit.
+# Eg.
+#      if dataset.uris is not None and len(dataset.uris) == 0:
+# vs
+#      if dataset.uris is not None and not dataset.uris:
 
-disable=no-self-use,
-    star-args,
-#   duplicate-code,
-    unused-argument,
-    missing-docstring,
-    no-member,
-    unused-variable,
-#   unused-import,
-    locally-disabled,
-    no-name-in-module,
-    fixme,
-    no-value-for-parameter,
-#   file-ignored,
-    no-absolute-import,
-    old-division,
-    wrong-import-order,
-    ungrouped-imports,
-    inconsistent-return-statements, # pylint bug
-    len-as-condition,
-    no-else-return,
-    too-many-lines,
-    comprehension-escape,
-    round-builtin, # py2.7
-    map-builtin-not-iterating, # py2.7
-    range-builtin-not-iterating, # py2.7
-    zip-builtin-not-iterating, # py2.7
-    nonzero-method, # py2.7
-    eq-without-hash, # py2.7
-    useless-object-inheritance
+disable=all
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=print-statement,
+       parameter-unpacking,
+       unpacking-in-except,
+       old-raise-syntax,
+       backtick,
+       long-suffix,
+       old-ne-operator,
+       old-octal-literal,
+       import-star-module-level,
+       non-ascii-bytes-literal,
+       invalid-unicode-literal,
+       c-extension-no-member,
+       apply-builtin,
+       basestring-builtin,
+       buffer-builtin,
+       cmp-builtin,
+       coerce-builtin,
+       execfile-builtin,
+       file-builtin,
+       long-builtin,
+       raw_input-builtin,
+       reduce-builtin,
+       standarderror-builtin,
+       unicode-builtin,
+       xrange-builtin,
+       coerce-method,
+       delslice-method,
+       getslice-method,
+       setslice-method,
+       dict-iter-method,
+       dict-view-method,
+       next-method-called,
+       metaclass-assignment,
+       indexing-exception,
+       raising-string,
+       reload-builtin,
+       oct-method,
+       hex-method,
+       nonzero-method,
+       cmp-method,
+       input-builtin,
+       round-builtin,
+       intern-builtin,
+       unichr-builtin,
+       map-builtin-not-iterating,
+       zip-builtin-not-iterating,
+       range-builtin-not-iterating,
+       filter-builtin-not-iterating,
+       using-cmp-argument,
+       eq-without-hash,
+       div-method,
+       idiv-method,
+       rdiv-method,
+       exception-message-attribute,
+       invalid-str-codec,
+       sys-max-int,
+       bad-python3-import,
+       deprecated-string-function,
+       deprecated-str-translate-call,
+       deprecated-itertools-function,
+       deprecated-types-field,
+       next-method-defined,
+       dict-items-not-iterating,
+       dict-keys-not-iterating,
+       dict-values-not-iterating,
+       deprecated-operator-function,
+       deprecated-urllib-function,
+       xreadlines-attribute,
+       deprecated-sys-function,
+       exception-escape,
+       useless-import-alias
+
 
 [BASIC]
 
@@ -41,7 +91,7 @@ disable=no-self-use,
 bad-functions=apply,input
 
 # Regular expression which should only match correct module names
-module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+module-rgx=(([a-z_][a-z0-9-_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression which should only match correct module level names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|_log)$
@@ -169,10 +219,8 @@ ignored-argument-names=_.*
 # Maximum number of locals for function / method body
 max-locals=16
 
-# Early return often results in clearer code.
-# The other complexity metrics are enough to prevent abuse.
 # Maximum number of return / yield for function / method body
-max-returns=128
+max-returns=6
 
 # Maximum number of branch for function / method body
 max-branches=12
@@ -198,3 +246,6 @@ max-public-methods=20
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
 overgeneral-exceptions=Exception
+
+[MASTER]
+extension-pkg-whitelist=dawg,lxml


### PR DESCRIPTION
On the 27th of February, pylint 2.3 was released, introducing a new no-else-raise flag. This complains about if statements of a particular structure that contain raise directives:
http://pylint.pycqa.org/en/stable/whatsnew/2.3.html?highlight=no-else-raise

After discussion with @omad, we have opted to implement a pylint whitelist as opposed to a blacklist.
To achieve this, I copied pylintrc from digitalearthau so that we explicitly enable flags we care about.
Also, updated readme to use correct badges and removed coveralls badge.
